### PR TITLE
feat: Improve scope output visualization, show confidence badge, and fix View in Devin link

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -791,6 +791,215 @@ body {
   text-decoration: underline;
 }
 
+/* Confidence Badge */
+.confidence-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.25rem 0.625rem;
+  border-radius: 12px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border: 1px solid;
+}
+
+.confidence-badge-small {
+  padding: 0.125rem 0.5rem;
+  font-size: 0.75rem;
+}
+
+.confidence-label {
+  font-weight: 500;
+  opacity: 0.9;
+}
+
+.confidence-high {
+  background: rgba(63, 185, 80, 0.15);
+  color: var(--accent-green);
+  border-color: rgba(63, 185, 80, 0.3);
+}
+
+.confidence-medium {
+  background: rgba(210, 153, 34, 0.15);
+  color: var(--accent-yellow);
+  border-color: rgba(210, 153, 34, 0.3);
+}
+
+.confidence-low {
+  background: rgba(248, 81, 73, 0.15);
+  color: var(--accent-red);
+  border-color: rgba(248, 81, 73, 0.3);
+}
+
+/* Raw JSON Panel */
+.raw-json-panel {
+  margin-top: 1rem;
+}
+
+.raw-json-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  color: var(--text-secondary);
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  width: 100%;
+  text-align: left;
+  transition: all 0.2s;
+}
+
+.raw-json-toggle:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.toggle-icon {
+  font-size: 0.7rem;
+}
+
+.raw-json-content {
+  background: var(--bg-primary);
+  padding: 1rem;
+  border-radius: 0 0 6px 6px;
+  border: 1px solid var(--border-color);
+  border-top: none;
+  font-size: 0.8rem;
+  overflow-x: auto;
+  max-height: 300px;
+  overflow-y: auto;
+  line-height: 1.5;
+  margin-top: -1px;
+}
+
+/* Scope Summary */
+.scope-summary {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-color);
+}
+
+.scope-confidence-section {
+  margin-bottom: 1rem;
+}
+
+.scope-confidence-header {
+  margin-bottom: 0.5rem;
+}
+
+.scope-confidence-rationale {
+  color: var(--text-secondary);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.scope-ready-status {
+  margin-bottom: 1rem;
+}
+
+.ready-indicator {
+  display: inline-block;
+  padding: 0.25rem 0.75rem;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  border: 1px solid;
+}
+
+.ready-indicator.ready {
+  background: rgba(63, 185, 80, 0.15);
+  color: var(--accent-green);
+  border-color: rgba(63, 185, 80, 0.3);
+}
+
+.ready-indicator.not-ready {
+  background: rgba(210, 153, 34, 0.15);
+  color: var(--accent-yellow);
+  border-color: rgba(210, 153, 34, 0.3);
+}
+
+.scope-section {
+  margin-bottom: 1rem;
+}
+
+.scope-section.highlighted {
+  background: rgba(210, 153, 34, 0.1);
+  padding: 0.75rem;
+  border-radius: 6px;
+  border: 1px solid rgba(210, 153, 34, 0.2);
+}
+
+.scope-section-title {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.scope-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: var(--text-primary);
+  font-size: 0.875rem;
+}
+
+.scope-list li {
+  margin-bottom: 0.25rem;
+  line-height: 1.5;
+}
+
+.scope-empty {
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  font-style: italic;
+  margin: 0;
+}
+
+.scope-action-plan {
+  margin: 0;
+  padding-left: 1.25rem;
+  counter-reset: step-counter;
+}
+
+.action-step {
+  margin-bottom: 0.75rem;
+  line-height: 1.5;
+}
+
+.action-step-title {
+  display: block;
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 0.875rem;
+}
+
+.action-step-details {
+  display: block;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  margin-top: 0.125rem;
+}
+
+/* Session link disabled state */
+.session-link-disabled {
+  display: inline-block;
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.session-link-helper {
+  color: var(--text-muted);
+  font-size: 0.75rem;
+  font-style: italic;
+  margin-left: 0.5rem;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
   .container {

--- a/src/components/ConfidenceBadge.tsx
+++ b/src/components/ConfidenceBadge.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+interface ConfidenceBadgeProps {
+  score: number;
+  showLabel?: boolean;
+  size?: 'small' | 'medium';
+}
+
+export function ConfidenceBadge({ score, showLabel = false, size = 'medium' }: ConfidenceBadgeProps) {
+  const getScoreColor = (score: number) => {
+    if (score >= 80) return 'confidence-high';
+    if (score >= 50) return 'confidence-medium';
+    return 'confidence-low';
+  };
+
+  const sizeClass = size === 'small' ? 'confidence-badge-small' : '';
+
+  return (
+    <span className={`confidence-badge ${getScoreColor(score)} ${sizeClass}`}>
+      {showLabel && <span className="confidence-label">Confidence:</span>}
+      <span className="confidence-score">{score}</span>
+    </span>
+  );
+}

--- a/src/components/RawJsonPanel.tsx
+++ b/src/components/RawJsonPanel.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useState } from 'react';
+
+interface RawJsonPanelProps {
+  data: unknown;
+  title?: string;
+}
+
+export function RawJsonPanel({ data, title = 'Raw Output' }: RawJsonPanelProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <div className="raw-json-panel">
+      <button
+        className="raw-json-toggle"
+        onClick={() => setIsExpanded(!isExpanded)}
+        aria-expanded={isExpanded}
+      >
+        <span className="toggle-icon">{isExpanded ? '▼' : '▶'}</span>
+        <span>{title}</span>
+      </button>
+      {isExpanded && (
+        <pre className="raw-json-content">
+          {JSON.stringify(data, null, 2)}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/src/components/ScopeSummary.tsx
+++ b/src/components/ScopeSummary.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { ConfidenceBadge } from './ConfidenceBadge';
+import { RawJsonPanel } from './RawJsonPanel';
+import { ScopeOutputSchema, type ScopeOutput } from '@/lib/schemas';
+
+interface ScopeSummaryProps {
+  data: Record<string, unknown>;
+}
+
+function parseStructuredOutput(data: Record<string, unknown>): ScopeOutput | null {
+  try {
+    const result = ScopeOutputSchema.safeParse(data);
+    if (result.success) {
+      return result.data;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+interface ListSectionProps {
+  title: string;
+  items: string[];
+}
+
+function ListSection({ title, items }: ListSectionProps) {
+  return (
+    <div className="scope-section">
+      <h5 className="scope-section-title">{title}</h5>
+      {items.length > 0 ? (
+        <ul className="scope-list">
+          {items.map((item, index) => (
+            <li key={index}>{item}</li>
+          ))}
+        </ul>
+      ) : (
+        <p className="scope-empty">None</p>
+      )}
+    </div>
+  );
+}
+
+export function ScopeSummary({ data }: ScopeSummaryProps) {
+  const parsed = parseStructuredOutput(data);
+
+  if (!parsed) {
+    return <RawJsonPanel data={data} title="Raw Output (parsing failed)" />;
+  }
+
+  return (
+    <div className="scope-summary">
+      <div className="scope-confidence-section">
+        <div className="scope-confidence-header">
+          <ConfidenceBadge score={parsed.confidence_score} showLabel />
+        </div>
+        <p className="scope-confidence-rationale">{parsed.confidence_rationale}</p>
+      </div>
+
+      <div className="scope-ready-status">
+        <span className={`ready-indicator ${parsed.ready_to_execute ? 'ready' : 'not-ready'}`}>
+          {parsed.ready_to_execute ? 'Ready to Execute' : 'Not Ready'}
+        </span>
+      </div>
+
+      <div className="scope-section">
+        <h5 className="scope-section-title">Action Plan</h5>
+        <ol className="scope-action-plan">
+          {parsed.action_plan.map((step) => (
+            <li key={step.step} className="action-step">
+              <span className="action-step-title">{step.title}</span>
+              <span className="action-step-details">{step.details}</span>
+            </li>
+          ))}
+        </ol>
+      </div>
+
+      <ListSection title="Assumptions" items={parsed.assumptions} />
+      
+      <div className={`scope-section ${!parsed.ready_to_execute ? 'highlighted' : ''}`}>
+        <h5 className="scope-section-title">Unknowns</h5>
+        {parsed.unknowns.length > 0 ? (
+          <ul className="scope-list">
+            {parsed.unknowns.map((item, index) => (
+              <li key={index}>{item}</li>
+            ))}
+          </ul>
+        ) : (
+          <p className="scope-empty">None</p>
+        )}
+      </div>
+
+      <ListSection title="Risks" items={parsed.risks} />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

This PR addresses GitHub Issue #7 by improving the scope output visualization, adding confidence badges, and fixing the View in Devin button.

## Changes

### New Components
- **ConfidenceBadge**: Displays confidence score as a colored badge (green for high, yellow for medium, red for low)
- **RawJsonPanel**: Collapsible panel for raw JSON fallback when parsing fails
- **ScopeSummary**: Renders structured scope output with confidence, action plan, assumptions/unknowns/risks

### SessionStatus Updates
- Replaced raw JSON rendering with ScopeSummary component for scope sessions
- Added confidence score badge next to Scope label in session header
- Fixed View in Devin button with proper disabled state when URL is unavailable

### CSS Additions
- Styles for confidence badges with color coding
- Styles for raw JSON panel with collapsible toggle
- Styles for scope summary sections
- Styles for disabled session link state

## Testing
- Build passes successfully
- Lint checks pass

Closes #7

---
**Link to Devin run:** https://app.devin.ai/sessions/17f403ddad1d4f5696a2421e83f004c7
**Requested by:** shorterjeremy@gmail.com (@jeremy-shr)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR enhances the scope output visualization by introducing new components to display structured scope data in a more user-friendly format. It adds a `ConfidenceBadge` component with color-coded confidence scores (green/yellow/red), a `ScopeSummary` component that renders action plans, assumptions, unknowns, and risks in an organized layout, and a collapsible `RawJsonPanel` for fallback display when parsing fails. The **View in Devin** button is also fixed to show a disabled state when the URL is unavailable, and a confidence badge is displayed in the session header for scope sessions.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `src/lib/schemas.ts` |
| 2 | `src/components/ConfidenceBadge.tsx` |
| 3 | `src/components/RawJsonPanel.tsx` |
| 4 | `src/components/ScopeSummary.tsx` |
| 5 | `src/components/SessionStatus.tsx` |
| 6 | `src/app/globals.css` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `src/lib/schemas.ts` | This file is referenced in the code (ScopeOutputSchema import) but is not included in the PR changes, making it impossible to verify the schema structure being used for parsing |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->