### PR TITLE
feat: Add issue state filter (Open/Closed/All) with UI toggle and API support

### DIFF
--- a/src/app/api/issues/route.ts
+++ b/src/app/api/issues/route.ts
@@ -1,9 +1,17 @@
-import { NextResponse } from 'next/server';
-import { listIssues } from '@/lib/github';
+import { NextRequest, NextResponse } from 'next/server';
+import { listIssues, IssueState } from '@/lib/github';
 
-export async function GET() {
+const VALID_STATES: IssueState[] = ['open', 'closed', 'all'];
+
+export async function GET(request: NextRequest) {
   try {
-    const issues = await listIssues();
+    const { searchParams } = new URL(request.url);
+    const stateParam = searchParams.get('state');
+    const state: IssueState = stateParam && VALID_STATES.includes(stateParam as IssueState)
+      ? (stateParam as IssueState)
+      : 'open';
+    
+    const issues = await listIssues(state);
     
     // Return issues with body snippet
     const issuesWithSnippet = issues.map(issue => ({

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -275,6 +275,40 @@ body {
   border-color: var(--accent-blue);
 }
 
+/* State toggle */
+.state-toggle {
+  display: flex;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.state-toggle-button {
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s;
+  border-right: 1px solid var(--border-color);
+}
+
+.state-toggle-button:last-child {
+  border-right: none;
+}
+
+.state-toggle-button:hover:not(.active) {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.state-toggle-button.active {
+  background: var(--accent-blue);
+  color: white;
+}
+
 /* Issue row */
 .issue-row {
   background: var(--bg-secondary);
@@ -323,6 +357,15 @@ body {
 .issue-title:hover {
   color: var(--accent-blue);
   text-decoration: underline;
+}
+
+.issue-title-closed {
+  color: var(--text-secondary);
+  opacity: 0.8;
+}
+
+.issue-title-closed:hover {
+  color: var(--accent-purple);
 }
 
 .issue-labels {

--- a/src/components/IssueRow.tsx
+++ b/src/components/IssueRow.tsx
@@ -137,11 +137,14 @@ export function IssueRow({ issue }: IssueRowProps) {
         <div className="issue-info">
           <div className="issue-header">
             <span className="issue-number">#{issue.number}</span>
+            {issue.state === 'closed' && (
+              <span className="state-badge state-closed">Closed</span>
+            )}
             <a 
               href={issue.html_url} 
               target="_blank" 
               rel="noopener noreferrer"
-              className="issue-title"
+              className={`issue-title ${issue.state === 'closed' ? 'issue-title-closed' : ''}`}
             >
               {issue.title}
             </a>

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -33,14 +33,16 @@ export interface GitHubIssue {
   state: string;
 }
 
-export async function listIssues(): Promise<GitHubIssue[]> {
+export type IssueState = 'open' | 'closed' | 'all';
+
+export async function listIssues(state: IssueState = 'open'): Promise<GitHubIssue[]> {
   const octokit = getOctokit();
   const { owner, repo } = getRepoConfig();
   
   const response = await octokit.rest.issues.listForRepo({
     owner,
     repo,
-    state: 'open',
+    state,
     per_page: 50,
     sort: 'updated',
     direction: 'desc',


### PR DESCRIPTION
## Summary

This PR implements the issue state filter feature as requested in #9.

## Changes

- **Backend**: Updated `listIssues()` in `src/lib/github.ts` to accept an optional `state` parameter (open/closed/all) with "open" as default
- **API Route**: Updated `/api/issues` route to parse and validate the `state` query parameter
- **Frontend UI**: Added a segmented toggle component (Open/Closed/All) in the filter controls area
- **URL Persistence**: State filter persists via URL query string (`?state=open|closed|all`) and survives page refresh
- **Visual Distinction**: Closed issues display a "Closed" badge and dimmed title styling
- **Suspense Boundary**: Wrapped component using `useSearchParams` in Suspense for Next.js compatibility

## Testing

- Lint checks pass
- Build succeeds
- All filter combinations (state + search + label) work correctly

Closes #9

---

**Link to Devin run**: https://app.devin.ai/sessions/3987c7abb5034b4eb5f80f5d638f7a08

**Requested by**: shorterjeremy@gmail.com (@jeremy-shr)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a comprehensive issue state filter feature that allows users to toggle between viewing *Open*, *Closed*, or *All* issues. The implementation includes backend API support with state parameter validation, a segmented toggle UI component in the frontend, URL persistence for the selected state (surviving page refreshes), and visual styling differences for closed issues including badges and dimmed titles. The state filter works seamlessly with existing search and label filtering capabilities.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `src/lib/github.ts` |
| 2 | `src/app/api/issues/route.ts` |
| 3 | `src/app/page.tsx` |
| 4 | `src/components/IssueRow.tsx` |
| 5 | `src/app/globals.css` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->