### PR TITLE
feat: Improve polling stability with retries/backoff and clearer error states

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1307,6 +1307,34 @@ body {
   border-color: var(--accent-blue);
 }
 
+/* Session reconnecting state */
+.session-reconnecting {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.375rem 0.625rem;
+  background: rgba(210, 153, 34, 0.1);
+  border: 1px solid rgba(210, 153, 34, 0.3);
+  border-radius: 4px;
+  color: var(--accent-yellow);
+  font-size: 0.8rem;
+  margin-bottom: 0.5rem;
+}
+
+/* Status strip reconnecting indicator */
+.status-strip-reconnecting {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.25rem 0.5rem;
+  background: rgba(210, 153, 34, 0.15);
+  border: 1px solid rgba(210, 153, 34, 0.3);
+  border-radius: 4px;
+  color: var(--accent-yellow);
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
   .container {

--- a/src/lib/usePollingWithBackoff.ts
+++ b/src/lib/usePollingWithBackoff.ts
@@ -1,0 +1,244 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+export interface PollingState {
+  isReconnecting: boolean;
+  isFailed: boolean;
+  failureCount: number;
+  nextRetryIn: number | null;
+}
+
+export interface UsePollingWithBackoffOptions<T> {
+  fetchFn: () => Promise<Response>;
+  onSuccess: (data: T) => void;
+  onPermanentError?: (error: string) => void;
+  isTerminal?: (data: T) => boolean;
+  normalInterval?: number;
+  maxFailures?: number;
+}
+
+interface BackoffConfig {
+  baseDelay: number;
+  maxDelay: number;
+  multiplier: number;
+}
+
+const DEFAULT_BACKOFF: BackoffConfig = {
+  baseDelay: 2000,
+  maxDelay: 60000,
+  multiplier: 2,
+};
+
+const TRANSIENT_STATUS_CODES = [429, 502, 503, 504];
+const PERMANENT_STATUS_CODES = [404];
+
+function isTransientError(status: number): boolean {
+  return TRANSIENT_STATUS_CODES.includes(status);
+}
+
+function isPermanentError(status: number): boolean {
+  return PERMANENT_STATUS_CODES.includes(status);
+}
+
+function calculateBackoffDelay(failureCount: number, config: BackoffConfig): number {
+  const delay = config.baseDelay * Math.pow(config.multiplier, failureCount - 1);
+  return Math.min(delay, config.maxDelay);
+}
+
+export function usePollingWithBackoff<T>({
+  fetchFn,
+  onSuccess,
+  onPermanentError,
+  isTerminal,
+  normalInterval = 15000,
+  maxFailures = 5,
+}: UsePollingWithBackoffOptions<T>) {
+  const [pollingState, setPollingState] = useState<PollingState>({
+    isReconnecting: false,
+    isFailed: false,
+    failureCount: 0,
+    nextRetryIn: null,
+  });
+  const [isPolling, setIsPolling] = useState(true);
+  
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const countdownRef = useRef<NodeJS.Timeout | null>(null);
+  const isMountedRef = useRef(true);
+  const pollRef = useRef<() => void>(() => {});
+
+  const clearTimers = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    if (countdownRef.current) {
+      clearInterval(countdownRef.current);
+      countdownRef.current = null;
+    }
+  }, []);
+
+  const scheduleNextPoll = useCallback((delay: number, isBackoff: boolean = false) => {
+    clearTimers();
+    
+    if (isBackoff) {
+      const startTime = Date.now();
+      const endTime = startTime + delay;
+      
+      setPollingState(prev => ({
+        ...prev,
+        nextRetryIn: Math.ceil(delay / 1000),
+      }));
+      
+      countdownRef.current = setInterval(() => {
+        if (!isMountedRef.current) return;
+        const remaining = Math.max(0, Math.ceil((endTime - Date.now()) / 1000));
+        setPollingState(prev => ({
+          ...prev,
+          nextRetryIn: remaining,
+        }));
+        if (remaining <= 0 && countdownRef.current) {
+          clearInterval(countdownRef.current);
+          countdownRef.current = null;
+        }
+      }, 1000);
+    }
+    
+    timeoutRef.current = setTimeout(() => {
+      if (isMountedRef.current) {
+        pollRef.current();
+      }
+    }, delay);
+  }, [clearTimers]);
+
+  const poll = useCallback(async () => {
+    if (!isMountedRef.current || !isPolling) return;
+
+    try {
+      const response = await fetchFn();
+      const status = response.status;
+      
+      if (!response.ok) {
+        if (isPermanentError(status)) {
+          setPollingState({
+            isReconnecting: false,
+            isFailed: true,
+            failureCount: maxFailures,
+            nextRetryIn: null,
+          });
+          setIsPolling(false);
+          
+          let errorMessage = 'Request failed';
+          try {
+            const errorData = await response.json();
+            errorMessage = errorData.error || errorMessage;
+          } catch {
+            // Ignore JSON parse errors
+          }
+          onPermanentError?.(errorMessage);
+          return;
+        }
+        
+        if (isTransientError(status)) {
+          const newFailureCount = pollingState.failureCount + 1;
+          
+          if (newFailureCount >= maxFailures) {
+            setPollingState({
+              isReconnecting: false,
+              isFailed: true,
+              failureCount: newFailureCount,
+              nextRetryIn: null,
+            });
+            setIsPolling(false);
+            return;
+          }
+          
+          const backoffDelay = calculateBackoffDelay(newFailureCount, DEFAULT_BACKOFF);
+          setPollingState({
+            isReconnecting: true,
+            isFailed: false,
+            failureCount: newFailureCount,
+            nextRetryIn: Math.ceil(backoffDelay / 1000),
+          });
+          scheduleNextPoll(backoffDelay, true);
+          return;
+        }
+        
+        throw new Error(`HTTP error: ${status}`);
+      }
+      
+      const data: T = await response.json();
+      
+      setPollingState({
+        isReconnecting: false,
+        isFailed: false,
+        failureCount: 0,
+        nextRetryIn: null,
+      });
+      
+      onSuccess(data);
+      
+      if (isTerminal?.(data)) {
+        setIsPolling(false);
+        return;
+      }
+      
+      scheduleNextPoll(normalInterval, false);
+      
+    } catch {
+      const newFailureCount = pollingState.failureCount + 1;
+      
+      if (newFailureCount >= maxFailures) {
+        setPollingState({
+          isReconnecting: false,
+          isFailed: true,
+          failureCount: newFailureCount,
+          nextRetryIn: null,
+        });
+        setIsPolling(false);
+        return;
+      }
+      
+      const backoffDelay = calculateBackoffDelay(newFailureCount, DEFAULT_BACKOFF);
+      setPollingState({
+        isReconnecting: true,
+        isFailed: false,
+        failureCount: newFailureCount,
+        nextRetryIn: Math.ceil(backoffDelay / 1000),
+      });
+      scheduleNextPoll(backoffDelay, true);
+    }
+  }, [fetchFn, onSuccess, onPermanentError, isTerminal, normalInterval, maxFailures, pollingState.failureCount, scheduleNextPoll, isPolling]);
+
+  // Keep pollRef updated with the latest poll function
+  useEffect(() => {
+    pollRef.current = poll;
+  }, [poll]);
+
+  const retry = useCallback(() => {
+    setPollingState({
+      isReconnecting: false,
+      isFailed: false,
+      failureCount: 0,
+      nextRetryIn: null,
+    });
+    setIsPolling(true);
+    pollRef.current();
+  }, []);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    pollRef.current();
+    
+    return () => {
+      isMountedRef.current = false;
+      clearTimers();
+    };
+  }, [clearTimers]);
+
+  return {
+    pollingState,
+    isPolling,
+    retry,
+  };
+}


### PR DESCRIPTION
## Summary

This PR implements polling stability improvements for session fetching as requested in issue #14.

## Changes

- **New `usePollingWithBackoff` hook** (`src/lib/usePollingWithBackoff.ts`): A shared polling hook that captures HTTP status before parsing JSON, classifies errors as transient (429, 502-504, network) vs permanent (404), implements exponential backoff (2s->4s->8s->16s->32s->60s cap), and tracks failure count.

- **Updated `SessionStatus.tsx`**: Refactored to use the new hook with proper error handling. Added "Reconnecting... (retrying in Xs)" UI state and "Unable to refresh session status. Please retry." error state with Retry button.

- **Updated `StatusStrip.tsx`**: Refactored `useSessionPoller` to use the new hook. Added subtle reconnecting indicator instead of silent failure.

- **CSS styles** (`globals.css`): Added styles for reconnecting warning state and failed error state.

## Acceptance Criteria

- [x] Transient failures do not permanently break the UI; polling recovers automatically
- [x] The user is informed when the system is retrying vs genuinely failed
- [x] Terminal states still stop polling cleanly (finished, blocked, failed, cancelled, expired)

Fixes #14

---

**Link to Devin run:** https://app.devin.ai/sessions/1ad5c633e3f549bbb98cdc12b207566b

**Requested by:** shorterjeremy@gmail.com (@jeremy-shr)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a robust polling mechanism with exponential backoff and retry logic to handle transient failures gracefully when fetching session status. The new `usePollingWithBackoff` hook classifies errors as transient (429, 502-504, network errors) versus permanent (404), implements exponential backoff with a capped retry strategy, and provides clear UI feedback through reconnecting and failed states. Both `SessionStatus` and `StatusStrip` components have been refactored to use this new hook, displaying countdown timers during reconnection attempts and offering manual retry buttons when failures occur. Visual indicators have been added through CSS styles to communicate the reconnecting and error states to users.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `src/lib/usePollingWithBackoff.ts` |
| 2 | `src/components/SessionStatus.tsx` |
| 3 | `src/components/StatusStrip.tsx` |
| 4 | `src/app/globals.css` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->